### PR TITLE
Option to disable generate archives.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@
 
 var assign = require('object-assign');
 
+if (hexo.config.archive != false) {
+
 // when archive disabled pagination, per_page should be 0.
 var per_page;
 
@@ -23,3 +25,5 @@ hexo.config.archive_generator = assign({
 }, hexo.config.archive_generator);
 
 hexo.extend.generator.register('archive', require('./lib/generator'));
+
+}

--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@
 
 var assign = require('object-assign');
 
-if (hexo.config.archive_dir !== false) {
-
 // when archive disabled pagination, per_page should be 0.
 var per_page;
+
+if (hexo.config.archive !== false) {
 
 if (hexo.config.archive === 1) {
   per_page = 0;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 var assign = require('object-assign');
 
-if (typeof hexo.config.archive_generator.enable === 'undefined' || hexo.config.archive_generator.enable !== false) {
+if (hexo.config.archive_dir !== false) {
 
 // when archive disabled pagination, per_page should be 0.
 var per_page;

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var assign = require('object-assign');
 // when archive disabled pagination, per_page should be 0.
 var per_page;
 
-if (hexo.config.archive !== false) {
+//if (hexo.config.archive !== false) {
 
 if (hexo.config.archive === 1) {
   per_page = 0;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 var assign = require('object-assign');
 
-if (typeof hexo.config.archive_generator.enable === 'undefined' || hexo.config.archive_generator.enable != false) {
+if (typeof hexo.config.archive_generator.enable === 'undefined' || hexo.config.archive_generator.enable !== false) {
 
 // when archive disabled pagination, per_page should be 0.
 var per_page;

--- a/index.js
+++ b/index.js
@@ -26,4 +26,4 @@ hexo.config.archive_generator = assign({
 
 hexo.extend.generator.register('archive', require('./lib/generator'));
 
-}
+//}

--- a/index.js
+++ b/index.js
@@ -7,8 +7,6 @@ var assign = require('object-assign');
 // when archive disabled pagination, per_page should be 0.
 var per_page;
 
-//if (hexo.config.archive !== false) {
-
 if (hexo.config.archive === 1) {
   per_page = 0;
 } else if (typeof hexo.config.per_page === 'undefined') {
@@ -26,4 +24,4 @@ hexo.config.archive_generator = assign({
 
 hexo.extend.generator.register('archive', require('./lib/generator'));
 
-//}
+

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 var assign = require('object-assign');
 
-if (hexo.config.archive != false) {
+if (typeof hexo.config.archive_generator.enable === 'undefined' || hexo.config.archive_generator.enable != false) {
 
 // when archive disabled pagination, per_page should be 0.
 var per_page;


### PR DESCRIPTION
If in root hexo config add `archive: false` option, archives generating will disabled totally for whole site.
This usefull for generate multisites (hexo g --config _custom.yml) when on one site need archives and on other site archives is no need.