### PR TITLE
修复 archive_generator 的 enable 无效的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-if (!(hexo.config.archive && hexo.config.archive.enabled === false)) {
+if (!(hexo.config.archive_generator && hexo.config.archive_generator.enabled === false)) {
   // when archive disabled pagination, per_page should be 0.
   let per_page;
 


### PR DESCRIPTION
设置了 archive_generator 的 enable 似乎无效
看了代码也没找到有判断 enable 的地方
这句是不是写错了